### PR TITLE
Added missing curly brace for #ifdef __cplusplus

### DIFF
--- a/common/bsp_driver_if.h
+++ b/common/bsp_driver_if.h
@@ -435,4 +435,8 @@ extern bsp_driver_if_t *bsp_driver_if_g;
  * API FUNCTIONS
  **********************************************************************************************************************/
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif // BSP_DRIVER_IF_H


### PR DESCRIPTION
common/bsp_driver_if.h was missing the closing curly brace for `extern C {`